### PR TITLE
Fix hash_key from global_secondary_index

### DIFF
--- a/week8.5/dynamodb/resources.tf
+++ b/week8.5/dynamodb/resources.tf
@@ -24,8 +24,7 @@ resource "aws_dynamodb_table" "sneakers_table" {
 
   global_secondary_index {
     name               = "Sneakers_GSI"
-    hash_key           = "BrandName"
-    range_key          = "ModelNumber"
+    hash_key           = "ModelNumber"
     write_capacity     = 10
     read_capacity      = 10
     projection_type    = "ALL"


### PR DESCRIPTION
Hi Romy.
I was reading your excellent medium article https://blog.devgenius.io/deploying-a-dynamodb-table-using-terraform-modules-ae5621312f10.
This pull request fix for the DynamoDB table. There is no sense in using the same hash_key for table and global_table.

Regards.

